### PR TITLE
add temporary auth flow

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,6 +23,7 @@
       }
     },
     "..": {
+      "name": "project-mern",
       "version": "1.0.0",
       "devDependencies": {
         "concurrently": "^8.2.2"

--- a/client/src/AppRoutes.jsx
+++ b/client/src/AppRoutes.jsx
@@ -9,21 +9,53 @@ import TicketView from './pages/TicketView/TicketView';
 import ConcertList from './pages/ConcertList/ConcertList';
 import EditConcert from './pages/EditConcert/EditConcert';
 import Validator from './pages/Validator/Validator';
+import ProtectedRoute from './components/ProtectedRoute/ProtectedRoute';
 
 export default function AppRoutes() {
   return (
     <Routes>
+      {/* Public routes */}
       <Route path="/" element={<Home />} />
       <Route path="/buy/:id" element={<BuyTickets />} />
       <Route path="/return" element={<BuyTicketsReturn />} />
       <Route path="/concert/:id" element={<ConcertDetails />} />
       <Route path="/auth" element={<Auth />} />
-      <Route path="/my-orders" element={<MyOrders />} />
-      <Route path="/my-orders/:orderId" element={<TicketView />} />
-      <Route path="/admin" element={<ConcertList />} />
-      <Route path="/edit/:id" element={<EditConcert />} />
-      <Route path="/create" element={<CreateConcert />} />
-      <Route path="/validator" element={<Validator />} />
+
+      {/* User routes */}
+      <Route path="/my-orders" element={
+        <ProtectedRoute roles={['admin', 'user']}>
+          <MyOrders />
+        </ProtectedRoute>
+      } />
+      <Route path="/my-orders/:orderId" element={
+        <ProtectedRoute roles={['admin', 'user']}>
+          <TicketView />
+        </ProtectedRoute>
+      } />
+
+      {/* Scanner + admin routes */}
+      <Route path="/validator" element={
+        <ProtectedRoute roles={['admin', 'scanner']}>
+          <Validator />
+        </ProtectedRoute>
+      } />
+
+      {/* Admin only routes */}
+      <Route path="/admin" element={
+        <ProtectedRoute roles={['admin']}>
+          <ConcertList />
+        </ProtectedRoute>
+      } />
+      <Route path="/edit/:id" element={
+        <ProtectedRoute roles={['admin']}>
+          <EditConcert />
+        </ProtectedRoute>
+      } />
+      <Route path="/create" element={
+        <ProtectedRoute roles={['admin']}>
+          <CreateConcert />
+        </ProtectedRoute>
+      } />
     </Routes>
   );
 }

--- a/client/src/Root.jsx
+++ b/client/src/Root.jsx
@@ -1,3 +1,4 @@
+import { AuthProvider } from './context/AuthContext';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Navbar from './components/Navbar/Navbar';
@@ -7,11 +8,13 @@ const queryClient = new QueryClient();
 
 export default function Root() {
   return (
+    <AuthProvider>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <Navbar />
         <AppRoutes />
       </BrowserRouter>
     </QueryClientProvider>
+    </AuthProvider>
   );
 }

--- a/client/src/components/Navbar/Navbar.jsx
+++ b/client/src/components/Navbar/Navbar.jsx
@@ -1,9 +1,16 @@
 import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 import { styles } from './Navbar.styles';
 
 export default function Navbar() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const { user, isAuthenticated, isAdmin, isScanner, logout } = useAuth();
+
+  const handleLogout = async () => {
+    await logout();
+    navigate('/');
+  };
 
   return (
     <div style={styles.wrapper}>
@@ -12,20 +19,57 @@ export default function Navbar() {
           <span style={styles.logoPrimary}>Ticket</span>
           <span style={styles.logoSecondary}>Flow</span>
         </div>
+
         <div style={styles.links}>
-          <button style={{ ...styles.link, ...(pathname === '/admin' ? styles.linkActive : {}) }} onClick={() => navigate('/admin')}>
-            Concert List
-          </button>
-          <button style={{ ...styles.link, ...(pathname === '/validator' ? styles.linkActive : {}) }} onClick={() => navigate('/validator')}>
-            Validator
-          </button>
-          <button style={{ ...styles.link, ...(pathname === '/auth' ? styles.linkActive : {}) }} onClick={() => navigate('/auth')}>
-            Sign In
-          </button>
+          {isAdmin && (
+            <button
+              style={{ ...styles.link, ...(pathname === '/admin' ? styles.linkActive : {}) }}
+              onClick={() => navigate('/admin')}
+            >
+              Concert List
+            </button>
+          )}
+
+          {(isAdmin || isScanner) && (
+            <button
+              style={{ ...styles.link, ...(pathname === '/validator' ? styles.linkActive : {}) }}
+              onClick={() => navigate('/validator')}
+            >
+              Validator
+            </button>
+          )}
+
+          {isAuthenticated && !isScanner && !isAdmin && (
+            <button
+              style={{ ...styles.link, ...(pathname === '/my-orders' ? styles.linkActive : {}) }}
+              onClick={() => navigate('/my-orders')}
+            >
+              My Tickets
+            </button>
+          )}
+
+          {isAuthenticated ? (
+            <>
+              <span style={styles.link}>{user.name}</span>
+              <button style={styles.link} onClick={handleLogout}>
+                Sign Out
+              </button>
+            </>
+          ) : (
+            <button
+              style={{ ...styles.link, ...(pathname === '/auth' ? styles.linkActive : {}) }}
+              onClick={() => navigate('/auth')}
+            >
+              Sign In
+            </button>
+          )}
         </div>
       </nav>
+
       {pathname !== '/' && (
-        <button style={styles.backBtn} onClick={() => navigate(-1)}>← Back</button>
+        <button style={styles.backBtn} onClick={() => navigate(-1)}>
+          Back
+        </button>
       )}
     </div>
   );

--- a/client/src/components/ProtectedRoute/ProtectedRoute.jsx
+++ b/client/src/components/ProtectedRoute/ProtectedRoute.jsx
@@ -1,0 +1,16 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+export default function ProtectedRoute({ children, roles }) {
+  const { user, loading } = useAuth();
+
+  // Wait for session check before making any redirect decision
+  if (loading) return null;
+
+  if (!user) return <Navigate to="/auth" replace />;
+
+  if (roles && !roles.includes(user.role))
+    return <Navigate to="/" replace />;
+
+  return children;
+}

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+import { fetchMe, loginUser, registerUser, logoutUser } from '../services/api/api';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  // Check for active session on every page load
+  useEffect(() => {
+    fetchMe()
+      .then(data => setUser(data))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const login = async (email, password) => {
+    const data = await loginUser({ email, password });
+    setUser(data.user);
+  };
+
+  const register = async (name, email, password) => {
+    const data = await registerUser({ name, email, password });
+    setUser(data.user);
+  };
+
+  const logout = async () => {
+    await logoutUser();
+    setUser(null);
+    setIsAuthenticated(false);
+};
+
+  return (
+    <AuthContext.Provider value={{
+      user,
+      loading,
+      login,
+      register,
+      logout,
+      isAuthenticated: !!user,
+      isAdmin:         user?.role === 'admin',
+      isScanner:       user?.role === 'scanner',
+    }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/client/src/pages/Auth/Auth.jsx
+++ b/client/src/pages/Auth/Auth.jsx
@@ -1,22 +1,45 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
 import { styles } from './Auth.styles';
 
-// TODO: import auth API hooks once implemented
-// TODO: decide on auth strategy (JWT, OAuth, etc.)
-
 export default function Auth() {
-  const [mode, setMode] = useState('login'); // 'login' | 'register'
+  const [mode, setMode] = useState('login');
+  const [formData, setFormData] = useState({ name: '', email: '', password: '' });
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
+  const { login, register } = useAuth();
+  const navigate = useNavigate();
   const isLogin = mode === 'login';
 
-  function handleSubmit(e) {
+  const handleChange = (e) =>
+    setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
+
+  async function handleSubmit(e) {
     e.preventDefault();
-    // TODO: call login or register API
+    setError('');
+    setLoading(true);
+    try {
+      if (isLogin) {
+        await login(formData.email, formData.password);
+      } else {
+        await register(formData.name, formData.email, formData.password);
+      }
+      navigate('/');
+    } catch (err) {
+      setError(err.message || 'Something went wrong, please try again');
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
     <div style={styles.page}>
-      <div className="glow-blob-pink" style={{ width: '400px', height: '300px', top: '-80px', left: '50%', transform: 'translateX(-50%)' }} />
+      <div
+        className="glow-blob-pink"
+        style={{ width: '400px', height: '300px', top: '-80px', left: '50%', transform: 'translateX(-50%)' }}
+      />
       <div style={styles.inner}>
         <div style={styles.header}>
           <p style={styles.eyebrow}>{isLogin ? 'Welcome Back' : 'Join Us'}</p>
@@ -34,20 +57,50 @@ export default function Auth() {
             {!isLogin && (
               <div style={styles.fieldGroup}>
                 <label style={styles.label}>Full Name</label>
-                <input style={styles.input} type="text" placeholder="Jane Smith" required />
+                <input
+                  style={styles.input}
+                  name="name"
+                  type="text"
+                  placeholder="Jane Smith"
+                  value={formData.name}
+                  onChange={handleChange}
+                  required
+                />
               </div>
             )}
             <div style={styles.fieldGroup}>
               <label style={styles.label}>Email</label>
-              <input style={styles.input} type="email" placeholder="you@example.com" required />
+              <input
+                style={styles.input}
+                name="email"
+                type="email"
+                placeholder="you@example.com"
+                value={formData.email}
+                onChange={handleChange}
+                required
+              />
             </div>
             <div style={styles.fieldGroup}>
               <label style={styles.label}>Password</label>
-              <input style={styles.input} type="password" placeholder="••••••••" required />
+              <input
+                style={styles.input}
+                name="password"
+                type="password"
+                placeholder="••••••••"
+                value={formData.password}
+                onChange={handleChange}
+                required
+              />
             </div>
-            {/* TODO: add validation and error messages */}
-            <button type="submit" style={styles.submitBtn}>
-              {isLogin ? 'Sign In' : 'Create Account'}
+
+            {error && (
+              <p style={{ color: '#ff6b6b', fontSize: '14px', textAlign: 'center' }}>
+                {error}
+              </p>
+            )}
+
+            <button type="submit" style={styles.submitBtn} disabled={loading}>
+              {loading ? 'Loading...' : isLogin ? 'Sign In' : 'Create Account'}
             </button>
           </form>
 
@@ -56,18 +109,17 @@ export default function Auth() {
             <span style={styles.dividerText}>or</span>
             <div style={styles.dividerLine} />
           </div>
-
-          {/* TODO: add OAuth buttons (Google, etc.) if needed */}
         </div>
 
         <p style={styles.toggleHint}>
           {isLogin ? "Don't have an account?" : 'Already have an account?'}{' '}
-          <button style={styles.toggleLink} onClick={() => setMode(isLogin ? 'register' : 'login')}>
+          <button
+            style={styles.toggleLink}
+            onClick={() => { setMode(isLogin ? 'register' : 'login'); setError(''); }}
+          >
             {isLogin ? 'Register' : 'Sign in'}
           </button>
         </p>
-
-        {/* TODO: add forgot password link */}
       </div>
     </div>
   );

--- a/client/src/services/api/api.js
+++ b/client/src/services/api/api.js
@@ -1,5 +1,7 @@
 const baseServerUrl = '/api';
 
+// --- Concerts ---
+
 export const fetchConcerts = () =>
   fetch(`${baseServerUrl}/concerts`).then((res) => {
     if (!res.ok) throw new Error(`Server error ${res.status}`);
@@ -38,11 +40,15 @@ export const updateConcert = (id, data) =>
     return res.json();
   });
 
+// --- Stats ---
+
 export const fetchStats = () =>
   fetch(`${baseServerUrl}/stats`).then((res) => {
     if (!res.ok) throw new Error(`Server error ${res.status}`);
     return res.json();
   });
+
+// --- Orders ---
 
 export const fetchMyOrders = () =>
   fetch(`${baseServerUrl}/orders`, { credentials: 'include' }).then((res) => {
@@ -56,12 +62,55 @@ export const fetchOrderById = (orderId) =>
     return res.json();
   });
 
+// --- Validator ---
+
 export const validateTicket = ({ transactionId, lastFourDigits }) =>
   fetch(`${baseServerUrl}/validator/validate`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ transactionId, lastFourDigits }),
+  }).then((res) => {
+    if (!res.ok) throw new Error(`Server error ${res.status}`);
+    return res.json();
+  });
+
+// --- Auth ---
+
+export const fetchMe = () =>
+  fetch(`${baseServerUrl}/auth/me`, {
+    credentials: 'include',
+  }).then((res) => {
+    if (!res.ok) throw new Error(`Server error ${res.status}`);
+    return res.json();
+  });
+
+export const loginUser = ({ email, password }) =>
+  fetch(`${baseServerUrl}/auth/login`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  }).then((res) => {
+    if (!res.ok) return res.json().then(data => Promise.reject(data));
+    return res.json();
+  });
+
+export const registerUser = ({ name, email, password }) =>
+  fetch(`${baseServerUrl}/auth/register`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, email, password }),
+  }).then((res) => {
+    if (!res.ok) return res.json().then(data => Promise.reject(data));
+    return res.json();
+  });
+
+export const logoutUser = () =>
+  fetch(`${baseServerUrl}/auth/logout`, {
+    method: 'POST',
+    credentials: 'include',
   }).then((res) => {
     if (!res.ok) throw new Error(`Server error ${res.status}`);
     return res.json();

--- a/server/db/models/Order.js
+++ b/server/db/models/Order.js
@@ -14,7 +14,8 @@ const orderSchema = new mongoose.Schema(
     orderId:         { type: String, unique: true, default: () => randomUUID() },
     concertId:       { type: mongoose.Schema.Types.ObjectId, ref: 'Concert', required: true },
     title:           { type: String, required: true },
-    customerEmail:   { type: String },
+    userId:          { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    customerEmail:   { type: String }, // email used for stripe checkout
     stripeSessionId: { type: String, unique: true, required: true },
     stripeLast4:     { type: String, required: true },
     tickets:         { type: [ticketSchema], default: [] },

--- a/server/db/models/User.js
+++ b/server/db/models/User.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+
+const userSchema = new mongoose.Schema(
+  {
+    name:           { type: String, required: true, trim: true },
+    email:          { type: String, required: true, unique: true, lowercase: true, trim: true },
+    password:       { type: String, required: true, minlength: 6, select: false },
+    role:           { type: String, enum: ['admin', 'user', 'scanner'], default: 'user' },
+    assignedEvents: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Concert' }],
+  },
+  { timestamps: true }
+);
+
+userSchema.pre('save', async function (next) {
+  if (!this.isModified('password')) return next();
+  this.password = await bcrypt.hash(this.password, 12);
+  next();
+});
+
+userSchema.methods.comparePassword = async function (candidate) {
+  return bcrypt.compare(candidate, this.password);
+};
+
+module.exports = mongoose.model('User', userSchema);

--- a/server/db/seed.js
+++ b/server/db/seed.js
@@ -1,6 +1,7 @@
 const { connect } = require('./connection');
 const Message = require('./models/Message');
 const Concert = require('./models/Concert');
+const User = require('./models/User');
 const { concerts } = require('../mock/concerts');
 
 async function seed() {
@@ -18,6 +19,32 @@ async function seed() {
     console.log(`[seed] Seeded ${concerts.length} concerts.`);
   } else {
     console.log(`[seed] Concerts collection already has ${concertCount} document(s) — skipping.`);
+  }
+
+  const adminExists = await User.findOne({ email: 'admin@ticketflow.com' });
+  if (!adminExists) {
+    await User.create({
+      name: 'Admin',
+      email: 'admin@ticketflow.com',
+      password: 'Admin1234!',
+      role: 'admin',
+    });
+    console.log('[seed] Admin user created.');
+  } else {
+    console.log('[seed] Admin user already exists — skipping.');
+  }
+
+  const scannerExists = await User.findOne({ email: 'scanner@ticketflow.com' });
+  if (!scannerExists) {
+    await User.create({
+      name: 'Scanner',
+      email: 'scanner@ticketflow.com',
+      password: 'Scanner1234!',
+      role: 'scanner',
+    });
+    console.log('[seed] Scanner user created.');
+  } else {
+    console.log('[seed] Scanner user already exists — skipping.');
   }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,10 @@ const statsRouter = require('./routes/stats');
 const ordersRouter = require('./routes/orders');
 const validatorRouter = require('./routes/validator');
 
+const cookieParser = require('cookie-parser');
+const authRouter = require('./routes/auth');
+const { optionalAuth } = require('./middleware/auth');
+
 const app = express();
 const PORT = process.env.PORT || 5010;
 
@@ -27,6 +31,7 @@ app.use(cors({
   credentials: true,
 }));
 app.use(express.json());
+app.use(cookieParser());
 
 // --- Swagger ---
 // Docs are generated from @openapi JSDoc annotations in route files and this file.
@@ -53,6 +58,7 @@ app.use('/api/concerts', concertsRouter);
 app.use('/api/stats', statsRouter);
 app.use('/api/orders', ordersRouter);
 app.use('/api/validator', validatorRouter);
+app.use('/api/auth', authRouter);
 
 /**
  * @openapi
@@ -96,7 +102,7 @@ function stripeUnconfiguredResponse(res) {
  *       200:
  *         description: clientSecret for Stripe embedded checkout
  */
-app.post('/api/create-checkout-session', async (req, res) => {
+app.post('/api/create-checkout-session', optionalAuth, async (req, res) => {
   if (!stripe) return stripeUnconfiguredResponse(res);
   try {
     const YOUR_DOMAIN = process.env.YOUR_DOMAIN || 'http://localhost:3000';
@@ -147,7 +153,7 @@ app.post('/api/create-checkout-session', async (req, res) => {
  *       200:
  *         description: Session status and customer email
  */
-app.get('/api/session-status', async (req, res) => {
+app.get('/api/session-status', optionalAuth, async (req, res) => {
   if (!stripe) return stripeUnconfiguredResponse(res);
   try {
     const session = await stripe.checkout.sessions.retrieve(req.query.session_id);
@@ -167,6 +173,7 @@ app.get('/api/session-status', async (req, res) => {
           Order.create({
             concertId,
             title,
+            userId: req.user?.id || null, 
             customerEmail: session.customer_details?.email || '',
             stripeSessionId: session.id,
             stripeLast4: stripeLast4,

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,7 @@ const validatorRouter = require('./routes/validator');
 
 const cookieParser = require('cookie-parser');
 const authRouter = require('./routes/auth');
-const { optionalAuth } = require('./middleware/auth');
+const { protect } = require('./middleware/auth');
 
 const app = express();
 const PORT = process.env.PORT || 5010;
@@ -102,7 +102,7 @@ function stripeUnconfiguredResponse(res) {
  *       200:
  *         description: clientSecret for Stripe embedded checkout
  */
-app.post('/api/create-checkout-session', optionalAuth, async (req, res) => {
+app.post('/api/create-checkout-session', protect, async (req, res) => {
   if (!stripe) return stripeUnconfiguredResponse(res);
   try {
     const YOUR_DOMAIN = process.env.YOUR_DOMAIN || 'http://localhost:3000';
@@ -153,14 +153,14 @@ app.post('/api/create-checkout-session', optionalAuth, async (req, res) => {
  *       200:
  *         description: Session status and customer email
  */
-app.get('/api/session-status', optionalAuth, async (req, res) => {
+app.get('/api/session-status', protect, async (req, res) => {
   if (!stripe) return stripeUnconfiguredResponse(res);
   try {
     const session = await stripe.checkout.sessions.retrieve(req.query.session_id);
 
     let order = null;
     if (session.status === 'complete') {
-      const existing = await Order.findOne({ stripeSessionId: session.id });
+      const existing = await Order.findOne({ stripeSessionId: session.id, userId: req.user?.id });
       if (!existing) {
         const { concertId, title, quantity } = session.metadata;
         const qty = parseInt(quantity) || 1;
@@ -173,7 +173,7 @@ app.get('/api/session-status', optionalAuth, async (req, res) => {
           Order.create({
             concertId,
             title,
-            userId: req.user?.id || null, 
+            userId: req.user?.id, 
             customerEmail: session.customer_details?.email || '',
             stripeSessionId: session.id,
             stripeLast4: stripeLast4,

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,49 @@
+const jwt = require('jsonwebtoken');
+const User = require('../db/models/User');
+
+// Verify token from cookie and attach user to request
+exports.protect = (req, res, next) => {
+  const token = req.cookies?.token;
+  if (!token) return res.status(401).json({ message: 'Authentication required' });
+
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    next();
+  } catch {
+    res.status(401).json({ message: 'Invalid or expired token' });
+  }
+};
+
+// Restrict access to specific roles
+exports.restrictTo = (...roles) => (req, res, next) => {
+  if (!roles.includes(req.user.role))
+    return res.status(403).json({ message: 'You do not have permission to perform this action' });
+  next();
+};
+
+// Attach user if token exists, continue either way (for guest-compatible routes)
+exports.optionalAuth = (req, res, next) => {
+  const token = req.cookies?.token;
+  if (token) {
+    try {
+      req.user = jwt.verify(token, process.env.JWT_SECRET);
+    } catch {
+      // invalid token - continue as guest
+    }
+  }
+  next();
+};
+
+// Scanner can only access events they are assigned to
+exports.canScanEvent = async (req, res, next) => {
+  if (req.user.role === 'admin') return next();
+  try {
+    const user = await User.findById(req.user.id);
+    const eventId = req.params.eventId || req.body.eventId;
+    if (!user?.assignedEvents?.some(id => id.toString() === eventId))
+      return res.status(403).json({ message: 'You are not assigned to this event' });
+    next();
+  } catch {
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -22,7 +22,7 @@ exports.restrictTo = (...roles) => (req, res, next) => {
 };
 
 // Attach user if token exists, continue either way (for guest-compatible routes)
-exports.optionalAuth = (req, res, next) => {
+exports.protect = (req, res, next) => {
   const token = req.cookies?.token;
   if (token) {
     try {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,9 +8,12 @@
       "name": "project-mern-server",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "jsonwebtoken": "^9.0.3",
         "mongoose": "^8.4.1",
         "project-mern": "file:..",
         "stripe": "^21.0.1",
@@ -22,6 +25,7 @@
       }
     },
     "..": {
+      "name": "project-mern",
       "version": "1.0.0",
       "devDependencies": {
         "concurrently": "^8.2.2"
@@ -163,6 +167,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -234,6 +247,12 @@
       "engines": {
         "node": ">=16.20.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -349,6 +368,25 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
@@ -436,6 +474,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -900,6 +947,55 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -916,6 +1012,18 @@
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -923,10 +1031,40 @@
       "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -1428,7 +1566,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/server/package.json
+++ b/server/package.json
@@ -10,9 +10,12 @@
     "seed": "node db/seed.js --seed"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.3",
     "mongoose": "^8.4.1",
     "project-mern": "file:..",
     "stripe": "^21.0.1",

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,86 @@
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const User = require('../db/models/User');
+const { protect } = require('../middleware/auth');
+
+const router = express.Router();
+
+const setTokenCookie = (res, token) => {
+  res.cookie('token', token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+  });
+};
+
+const signToken = (id, role) =>
+  jwt.sign({ id, role }, process.env.JWT_SECRET, {
+    expiresIn: role === 'scanner' ? '12h' : '7d',
+  });
+
+// POST /api/auth/register
+router.post('/register', async (req, res) => {
+  try {
+    const { name, email, password } = req.body;
+    if (!name || !email || !password)
+      return res.status(400).json({ message: 'All fields are required' });
+
+    const existing = await User.findOne({ email });
+    if (existing)
+      return res.status(400).json({ message: 'Email is already registered' });
+
+    const user = await User.create({ name, email, password });
+    const token = signToken(user._id, user.role);
+    setTokenCookie(res, token);
+
+    res.status(201).json({
+      user: { id: user._id, name: user.name, email: user.email, role: user.role },
+    });
+  } catch (err) {
+    console.error('Register error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// POST /api/auth/login
+router.post('/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password)
+      return res.status(400).json({ message: 'Email and password are required' });
+
+    const user = await User.findOne({ email }).select('+password');
+    if (!user || !(await user.comparePassword(password)))
+      return res.status(401).json({ message: 'Invalid email or password' });
+
+    const token = signToken(user._id, user.role);
+    setTokenCookie(res, token);
+
+    res.json({
+      user: { id: user._id, name: user.name, email: user.email, role: user.role },
+    });
+  } catch (err) {
+    console.error('Login error:', err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// POST /api/auth/logout
+router.post('/logout', (req, res) => {
+  res.clearCookie('token');
+  res.json({ message: 'Logged out successfully' });
+});
+
+// GET /api/auth/me — check active session on page refresh
+router.get('/me', protect, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id);
+    if (!user) return res.status(404).json({ message: 'User not found' });
+    res.json({ id: user._id, name: user.name, email: user.email, role: user.role });
+  } catch {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -1,50 +1,26 @@
 const express = require('express');
 const router = express.Router();
 const Order = require('../db/models/Order');
+const { protect } = require('../middleware/auth');
 
-/**
- * @openapi
- * /orders:
- *   get:
- *     summary: List all active orders
- *     tags: [Orders]
- *     responses:
- *       200:
- *         description: Array of { orderId, title }
- */
-router.get('/', async (_req, res) => {
+// GET /api/orders — admin sees all, user sees only their own
+router.get('/', protect, async (req, res) => {
   try {
-    const orders = await Order.find({ deletedAt: null }, 'orderId title');
+    const filter = { deletedAt: null, userId: req.user.id };
+
+    const orders = await Order.find(filter, 'orderId title createdAt tickets');
     res.json(orders);
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch orders' });
   }
 });
 
-/**
- * @openapi
- * /orders/{orderId}:
- *   get:
- *     summary: Get a single order by orderId
- *     tags: [Orders]
- *     parameters:
- *       - in: path
- *         name: orderId
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: Order with tickets
- *       404:
- *         description: Not found
- */
-router.get('/:orderId', async (req, res) => {
+// GET /api/orders/:orderId — user can only access their own order
+router.get('/:orderId', protect, async (req, res) => {
   try {
-    const order = await Order.findOne(
-      { orderId: req.params.orderId, deletedAt: null },
-      'orderId title tickets stripeSessionId'
-    );
+    const filter = { orderId: req.params.orderId, deletedAt: null, userId: req.user.id };
+
+    const order = await Order.findOne(filter, 'orderId title tickets stripeSessionId');
     if (!order) return res.status(404).json({ message: 'Order not found' });
     res.json(order);
   } catch (err) {

--- a/server/routes/validator.js
+++ b/server/routes/validator.js
@@ -1,40 +1,36 @@
 const express = require('express');
 const router = express.Router();
 const Order = require('../db/models/Order');
+const { protect, restrictTo } = require('../middleware/auth');
 
-router.post('/validate', async (req, res) => {
+// POST /api/validator/validate — admin and scanner only
+router.post('/validate', protect, restrictTo('admin', 'scanner'), async (req, res) => {
   const { transactionId, lastFourDigits } = req.body;
 
-  if (!transactionId || !lastFourDigits) {
+  if (!transactionId || !lastFourDigits)
     return res.status(400).json({ valid: false, reason: 'Missing fields' });
-  }
 
   const [stripeSessionId, ticketId] = transactionId.split('::');
 
-  if (!stripeSessionId || !ticketId) {
+  if (!stripeSessionId || !ticketId)
     return res.status(400).json({ valid: false, reason: 'Invalid transaction ID format' });
-  }
 
   try {
     const order = await Order.findOne({ stripeSessionId, deletedAt: null });
 
-    if (!order) {
+    if (!order)
       return res.json({ valid: false, reason: 'Order not found' });
-    }
 
-    if (order.stripeLast4 !== lastFourDigits) {
+    if (order.stripeLast4 !== lastFourDigits)
       return res.json({ valid: false, reason: 'Card digits do not match' });
-    }
 
     const ticket = order.tickets.find(t => t.ticketId === ticketId);
 
-    if (!ticket) {
+    if (!ticket)
       return res.json({ valid: false, reason: 'Ticket not found' });
-    }
 
-    if (ticket.status === 'redeemed') {
+    if (ticket.status === 'redeemed')
       return res.json({ valid: false, reason: 'Ticket already redeemed' });
-    }
 
     ticket.status = 'redeemed';
     await order.save();


### PR DESCRIPTION
**add user authentication and role-based access control**
- Add User model with bcrypt password hashing (admin, user, scanner roles)
- Add JWT authentication via HttpOnly cookies
- Add auth middleware: protect, restrictTo, canScanEvent
- Add auth routes: register, login, logout, /me
- Add userId to Order model, populated on purchase when authenticated
- Restrict orders to owner
- Restrict validator to admin and scanner roles
- Add AuthProvider context with login, register, logout, loading state
- Add role-based ProtectedRoute, update AppRoutes accordingly
- Wire up Auth page and Navbar to auth state
- Seed admin and scanner users